### PR TITLE
load  mkl_rt at runtime

### DIFF
--- a/sparse_dot_mkl/_mkl_interface.py
+++ b/sparse_dot_mkl/_mkl_interface.py
@@ -2,21 +2,14 @@ import warnings
 import ctypes as _ctypes
 
 # Load mkl_spblas through the libmkl_rt common interface
-# Check each of these library types
-_MKL_SO_LINUX = "libmkl_rt.so"
-_MKL_SO_OSX = "libmkl_rt.dylib"
-_MKL_SO_WINDOWS = "mkl_rt.dll"
-
-# There's probably a better way to do this
 _libmkl, _libmkl_loading_errors = None, []
-for so_file in [_MKL_SO_LINUX, _MKL_SO_OSX, _MKL_SO_WINDOWS]:
-    try:
-        _libmkl = _ctypes.cdll.LoadLibrary(so_file)
-        break
-    except (OSError, ImportError) as err:
-        _libmkl_loading_errors.append(err)
+try:
+    so_file = _ctypes.util.find_library('mkl_rt')
+    _libmkl = _ctypes.cdll.LoadLibrary(so_file)    
+except (OSError, ImportError) as err:
+    _libmkl_loading_errors.append(err)
 
-if _libmkl is None:
+if _libmkl._name is None:
     ierr_msg = "Unable to load the MKL libraries through libmkl_rt. Try setting $LD_LIBRARY_PATH."
     ierr_msg += "\n\t" + "\n\t".join(map(lambda x: str(x), _libmkl_loading_errors))
     raise ImportError(ierr_msg)

--- a/sparse_dot_mkl/_mkl_interface.py
+++ b/sparse_dot_mkl/_mkl_interface.py
@@ -1,10 +1,11 @@
 import warnings
 import ctypes as _ctypes
+import ctypes.util as _ctypes_util
 
 # Load mkl_spblas through the libmkl_rt common interface
 _libmkl, _libmkl_loading_errors = None, []
 try:
-    so_file = _ctypes.util.find_library('mkl_rt')
+    so_file = _ctypes_util.find_library('mkl_rt')
     _libmkl = _ctypes.cdll.LoadLibrary(so_file)    
 except (OSError, ImportError) as err:
     _libmkl_loading_errors.append(err)


### PR DESCRIPTION
(in reference to the [following block](https://github.com/flatironinstitute/sparse_dot/blob/493c0be532a6397e59d5079e8c1cd7cb4321eb1d/sparse_dot_mkl/_mkl_interface.py#L10)...)

replace iterative search for mkl_spblas (eg `_MKL_SO_LINUX = "libmkl_rt.so"`, ,`_MKL_SO_OSX = "libmkl_rt.dylib"`, `_MKL_SO_WINDOWS = "mkl_rt.dll"`) with `_ctypes.util.find_library('mkl_rt')`.

